### PR TITLE
Add Query Collector Module

### DIFF
--- a/lib/ts/station/FSM.ex
+++ b/lib/ts/station/FSM.ex
@@ -105,7 +105,7 @@ defmodule Station.FSM do
 
         :collect ->
           # If completed query, send to
-          dependency.collector.collect(itinerary)
+          dependency.collector.collect(itinerary, dependency)
           new_station_data = List.delete_at(station_data, 0)
           Logger.info(fn -> "Query #{Itinerary.get_query_id(itinerary)} is collected" end)
           next_state(:ready, new_station_data)

--- a/lib/ts/station/UQC_behaviour.ex
+++ b/lib/ts/station/UQC_behaviour.ex
@@ -1,0 +1,6 @@
+defmodule Station.UQCBehaviour do
+  @moduledoc """
+  Defines the interface expected from UQC
+  """
+  @callback receive_search_results(list()) :: any()
+end

--- a/lib/ts/station/collector_behaviour.ex
+++ b/lib/ts/station/collector_behaviour.ex
@@ -2,5 +2,5 @@ defmodule Station.CollectorBehaviour do
   @moduledoc """
   Defines the interface for the Query Collector.
   """
-  @callback collect(list()) :: any()
+  @callback collect(list(), any()) :: any()
 end

--- a/lib/ts/station/query_collector.ex
+++ b/lib/ts/station/query_collector.ex
@@ -1,0 +1,131 @@
+defmodule Station.QueryCollector do
+  @moduledoc """
+  Provides the implementation for the Collector behaviour using a GenServer.`
+  """
+
+  use GenServer, async: true
+  require Logger
+  @behaviour Station.CollectorBehaviour
+  @default_option %{max_itineraries: 10, timeout: 200}
+  @end_state %{max_itineraries: 1}
+
+  def start_link(itinerary, opts \\ @default_option, dependency) do
+    GenServer.start_link(__MODULE__, [itinerary, opts, dependency])
+  end
+
+  def init([itinerary, opts, dependency]) do
+    Logger.debug(fn -> "Starting Query Collector" end)
+    {:ok, {itinerary, opts, dependency}}
+  end
+
+  def stop(pid) do
+    Logger.debug(fn -> "Terminating Query Collector normally" end)
+    GenServer.stop(pid, :normal)
+  end
+
+  # Initialise Itinerary search
+  def search_itinerary(pid) do
+    Logger.debug(fn -> "Initialising Itinerary Search." end)
+    GenServer.cast(pid, :start)
+  end
+
+  # Send completed itinerary to Query Collector.
+  def collect(itinerary, dependency) do
+    itinerary_fn = dependency.itinerary
+    registry = dependency.registry
+
+    qid = itinerary_fn.get_query_id(itinerary)
+
+    Logger.debug(fn ->
+      "Collecting a completed itinerary for query id #{qid}"
+    end)
+
+    # Find process id of Query Collector
+    qc_pid = registry.lookup_query_id(qid)
+
+    GenServer.cast(qc_pid, {:collect, itinerary})
+  end
+
+  defp _yield_result(result, itinerary, dependency) do
+    itinerary_fn = dependency.itinerary
+    uqc = dependency.uqc
+
+    qid = itinerary_fn.get_query_id(itinerary)
+
+    Logger.debug(fn ->
+      "Yielding Itinerary Search results for to UQC for query: #{qid}"
+    end)
+
+    # Send itinerary search result to uqc.
+    uqc.receive_search_results(result)
+  end
+
+  defp _unregister_query(itinerary, dependency) do
+    registry = dependency.registry
+    itinerary_fn = dependency.itinerary
+
+    qid = itinerary_fn.get_query_id(itinerary)
+    Logger.debug(fn -> "Unregistering query: #{qid}" end)
+
+    # Unregister query using registry
+    registry.unregister_query(qid)
+  end
+
+  def handle_cast(:start, {itinerary, opts, dependency}) do
+    registry = dependency.registry
+    station = dependency.station
+    itinerary_fn = dependency.itinerary
+
+    # Get Source Station
+    src_station = itinerary_fn.get_query(itinerary).src_station
+    src_pid = registry.lookup_code(src_station)
+
+    # Start Itinerary Search
+    station.send_query(src_pid, itinerary)
+
+    {:noreply, {[], opts, itinerary, dependency}, opts.timeout}
+  end
+
+  def handle_cast(
+        {:collect, completed_itinerary},
+        {result, @end_state, itinerary, dependency}
+      ) do
+    # Add completed itinerary to result,
+    result = [completed_itinerary | result]
+
+    # Send Itinerary search result to UQC
+    _yield_result(result, itinerary, dependency)
+
+    _unregister_query(itinerary, dependency)
+
+    {:stop, :normal, nil}
+  end
+
+  def handle_cast({:collect, _completed_itinerary}, nil) do
+    {:noreply, nil}
+  end
+
+  def handle_cast(
+        {:collect, completed_itinerary},
+        {result, opts, itinerary, dependency}
+      ) do
+    # Add completed itinerary to result,
+    result = [completed_itinerary | result]
+
+    # Decrement number of itineraries to be processed
+    opts = Map.update!(opts, :max_itineraries, &(&1 - 1))
+    {:noreply, {result, opts, itinerary, dependency}, opts.timeout}
+  end
+
+  # Send results to UQC and terminate Query Collector if no complete itineraries
+  # obtained for a given time (_opts.timeout).
+  def handle_info(:timeout, {result, _opts, itinerary, dependency}) do
+    # Send Itinerary search result to UQC
+    _yield_result(result, itinerary, dependency)
+
+    _unregister_query(itinerary, dependency)
+
+    # Terminate Query Collector process
+    {:stop, :normal, nil}
+  end
+end

--- a/lib/ts/station/query_collector.ex
+++ b/lib/ts/station/query_collector.ex
@@ -9,13 +9,13 @@ defmodule Station.QueryCollector do
   @default_option %{max_itineraries: 10, timeout: 200}
   @end_state %{max_itineraries: 1}
 
-  def start_link(itinerary, opts \\ @default_option, dependency) do
-    GenServer.start_link(__MODULE__, [itinerary, opts, dependency])
+  def start_link(itinerary_acc, opts \\ @default_option, dependency) do
+    GenServer.start_link(__MODULE__, [itinerary_acc, opts, dependency])
   end
 
-  def init([itinerary, opts, dependency]) do
+  def init([itinerary_acc, opts, dependency]) do
     Logger.debug(fn -> "Starting Query Collector" end)
-    {:ok, {itinerary, opts, dependency}}
+    {:ok, {itinerary_acc, opts, dependency}}
   end
 
   def stop(pid) do
@@ -30,11 +30,11 @@ defmodule Station.QueryCollector do
   end
 
   # Send completed itinerary to Query Collector.
-  def collect(itinerary, dependency) do
+  def collect(itinerary_acc, dependency) do
     itinerary_fn = dependency.itinerary
     registry = dependency.registry
 
-    qid = itinerary_fn.get_query_id(itinerary)
+    qid = itinerary_fn.get_query_id(itinerary_acc)
 
     Logger.debug(fn ->
       "Collecting a completed itinerary for query id #{qid}"
@@ -43,89 +43,96 @@ defmodule Station.QueryCollector do
     # Find process id of Query Collector
     qc_pid = registry.lookup_query_id(qid)
 
-    GenServer.cast(qc_pid, {:collect, itinerary})
+    GenServer.cast(qc_pid, {:collect, itinerary_acc})
   end
 
-  defp _yield_result(result, itinerary, dependency) do
+  def handle_cast(:start, {itinerary_acc, opts, dependency}) do
+    registry = dependency.registry
+    station = dependency.station
+    itinerary_fn = dependency.itinerary
+
+    # Get Source Station
+    src_station = itinerary_fn.get_query(itinerary_acc).src_station
+    src_pid = registry.lookup_code(src_station)
+
+    # Start Itinerary Search
+    station.send_query(src_pid, itinerary_acc)
+
+    {:noreply, {[], opts, itinerary_acc, dependency}, opts.timeout}
+  end
+
+  def handle_cast(
+        {:collect, completed_itinerary_acc},
+        {result, @end_state, itinerary_acc, dependency}
+      ) do
+    itinerary_fn = dependency.itinerary
+
+    # Add completed itinerary to result,
+    itinerary = itinerary_fn.get_itinerary(completed_itinerary_acc)
+    result = [itinerary | result]
+
+    # Send Itinerary search result to UQC
+    _yield_result(result, itinerary_acc, dependency)
+
+    _unregister_query(itinerary_acc, dependency)
+
+    {:stop, :normal, nil}
+  end
+
+  def handle_cast({:collect, _completed_itinerary_acc}, nil) do
+    {:noreply, nil}
+  end
+
+  def handle_cast(
+        {:collect, completed_itinerary_acc},
+        {result, opts, itinerary_acc, dependency}
+      ) do
+    itinerary_fn = dependency.itinerary
+
+    # Add completed itinerary to result,
+    itinerary = itinerary_fn.get_itinerary(completed_itinerary_acc)
+    result = [itinerary | result]
+
+    # Decrement number of itineraries to be processed
+    opts = Map.update!(opts, :max_itineraries, &(&1 - 1))
+    {:noreply, {result, opts, itinerary_acc, dependency}, opts.timeout}
+  end
+
+  # Send results to UQC and terminate Query Collector if no complete itineraries
+  # obtained for a given time (_opts.timeout).
+  def handle_info(:timeout, {result, _opts, itinerary_acc, dependency}) do
+    # Send Itinerary search result to UQC
+    _yield_result(result, itinerary_acc, dependency)
+
+    _unregister_query(itinerary_acc, dependency)
+
+    # Terminate Query Collector process
+    {:stop, :normal, nil}
+  end
+
+  defp _yield_result(result, itinerary_acc, dependency) do
     itinerary_fn = dependency.itinerary
     uqc = dependency.uqc
 
-    qid = itinerary_fn.get_query_id(itinerary)
+    qid = itinerary_fn.get_query_id(itinerary_acc)
 
     Logger.debug(fn ->
-      "Yielding Itinerary Search results for to UQC for query: #{qid}"
+      "Yielding Itinerary Search results for to UQC for query: #{qid}" <>
+        " timestamp: #{System.system_time()}"
     end)
 
     # Send itinerary search result to uqc.
     uqc.receive_search_results(result)
   end
 
-  defp _unregister_query(itinerary, dependency) do
+  defp _unregister_query(itinerary_acc, dependency) do
     registry = dependency.registry
     itinerary_fn = dependency.itinerary
 
-    qid = itinerary_fn.get_query_id(itinerary)
+    qid = itinerary_fn.get_query_id(itinerary_acc)
     Logger.debug(fn -> "Unregistering query: #{qid}" end)
 
     # Unregister query using registry
     registry.unregister_query(qid)
-  end
-
-  def handle_cast(:start, {itinerary, opts, dependency}) do
-    registry = dependency.registry
-    station = dependency.station
-    itinerary_fn = dependency.itinerary
-
-    # Get Source Station
-    src_station = itinerary_fn.get_query(itinerary).src_station
-    src_pid = registry.lookup_code(src_station)
-
-    # Start Itinerary Search
-    station.send_query(src_pid, itinerary)
-
-    {:noreply, {[], opts, itinerary, dependency}, opts.timeout}
-  end
-
-  def handle_cast(
-        {:collect, completed_itinerary},
-        {result, @end_state, itinerary, dependency}
-      ) do
-    # Add completed itinerary to result,
-    result = [completed_itinerary | result]
-
-    # Send Itinerary search result to UQC
-    _yield_result(result, itinerary, dependency)
-
-    _unregister_query(itinerary, dependency)
-
-    {:stop, :normal, nil}
-  end
-
-  def handle_cast({:collect, _completed_itinerary}, nil) do
-    {:noreply, nil}
-  end
-
-  def handle_cast(
-        {:collect, completed_itinerary},
-        {result, opts, itinerary, dependency}
-      ) do
-    # Add completed itinerary to result,
-    result = [completed_itinerary | result]
-
-    # Decrement number of itineraries to be processed
-    opts = Map.update!(opts, :max_itineraries, &(&1 - 1))
-    {:noreply, {result, opts, itinerary, dependency}, opts.timeout}
-  end
-
-  # Send results to UQC and terminate Query Collector if no complete itineraries
-  # obtained for a given time (_opts.timeout).
-  def handle_info(:timeout, {result, _opts, itinerary, dependency}) do
-    # Send Itinerary search result to UQC
-    _yield_result(result, itinerary, dependency)
-
-    _unregister_query(itinerary, dependency)
-
-    # Terminate Query Collector process
-    {:stop, :normal, nil}
   end
 end

--- a/lib/ts/station/registry.ex
+++ b/lib/ts/station/registry.ex
@@ -40,6 +40,24 @@ defmodule Station.Registry do
     end
   end
 
+    # Returns the Query Collecotr pid associated with the query id
+    def lookup_query_id(qid) do
+      qc = :pg2.get_members({:qid, qid})
+
+      if is_list(qc) and qc != [] do
+        qc_pid = List.first(qc)
+
+        Logger.debug(fn ->
+          "Query ID lookup #{qid} -> #{qc_pid}"
+        end)
+
+        qc_pid
+      else
+        Logger.debug(fn -> "Query ID lookup failed for #{qid}" end)
+        nil
+      end
+    end
+
   # Checks whether the query is active. If there is no query collector
   # process associated with the qid process group it is assumed that the query
   # has gone stale

--- a/lib/ts/station/registry.ex
+++ b/lib/ts/station/registry.ex
@@ -40,23 +40,23 @@ defmodule Station.Registry do
     end
   end
 
-    # Returns the Query Collecotr pid associated with the query id
-    def lookup_query_id(qid) do
-      qc = :pg2.get_members({:qid, qid})
+  # Returns the Query Collecotr pid associated with the query id
+  def lookup_query_id(qid) do
+    qc = :pg2.get_members({:qid, qid})
 
-      if is_list(qc) and qc != [] do
-        qc_pid = List.first(qc)
+    if is_list(qc) and qc != [] do
+      qc_pid = List.first(qc)
 
-        Logger.debug(fn ->
-          "Query ID lookup #{qid} -> #{qc_pid}"
-        end)
+      Logger.debug(fn ->
+        "Query ID lookup #{qid} -> #{qc_pid}"
+      end)
 
-        qc_pid
-      else
-        Logger.debug(fn -> "Query ID lookup failed for #{qid}" end)
-        nil
-      end
+      qc_pid
+    else
+      Logger.debug(fn -> "Query ID lookup failed for #{qid}" end)
+      nil
     end
+  end
 
   # Checks whether the query is active. If there is no query collector
   # process associated with the qid process group it is assumed that the query

--- a/lib/ts/station/registry_behaviour.ex
+++ b/lib/ts/station/registry_behaviour.ex
@@ -3,6 +3,7 @@ defmodule Station.RegistryBehaviour do
   Implements the interface of the Network Constructor.
   """
   @callback lookup_code(String.t()) :: pid()
+  @callback lookup_query_id(String.t()) :: pid()
   @callback check_active(any()) :: boolean()
   @callback register_station(any(), pid()) :: any()
   @callback register_query(any(), pid()) :: any()

--- a/lib/ts/station/station.ex
+++ b/lib/ts/station/station.ex
@@ -15,7 +15,10 @@ defmodule Station do
   # Starting the GenServer
 
   def start_link(station_data) when is_list(station_data) do
-    Logger.info(fn -> "Station starting for station_number=#{hd(station_data).station_number}" end)
+    Logger.info(fn ->
+      "Station starting for station_number=#{hd(station_data).station_number}"
+    end)
+
     GenServer.start_link(Station, station_data)
   end
 
@@ -25,24 +28,28 @@ defmodule Station do
   end
 
   def stop(pid) do
-    Logger.info(fn -> "Station stopped at pid=#{inspect pid}" end)
+    Logger.info(fn -> "Station stopped at pid=#{inspect(pid)}" end)
     GenServer.stop(pid, :normal)
   end
 
   # Getting the current schedule
   def get_timetable(pid) do
-    Logger.info(fn -> "Getting the current schedule at pid=#{inspect pid}" end)
+    Logger.info(fn -> "Getting the current schedule at pid=#{inspect(pid)}" end)
+
     GenServer.call(pid, :get_schedule)
   end
 
   # Updating the current state
   def update(pid, new_vars) do
-    Logger.info(fn -> "Updating the current state at pid=#{inspect pid}" end)
+    Logger.info(fn -> "Updating the current state at pid=#{inspect(pid)}" end)
     GenServer.cast(pid, {:update, new_vars})
   end
 
   def send_query(pid, query) do
-    Logger.info(fn -> "Received query #{Itinerary.get_query_id(query)} at pid=#{inspect pid}" end)
+    Logger.info(fn ->
+      "Received query #{Itinerary.get_query_id(query)} at pid=#{inspect(pid)}"
+    end)
+
     GenServer.cast(pid, {:receive, query})
   end
 

--- a/lib/ts/util/itinerary_behaviour.ex
+++ b/lib/ts/util/itinerary_behaviour.ex
@@ -6,6 +6,7 @@ defmodule Util.ItineraryBehaviour do
   @callback valid_itinerary_iterator(any(), any()) :: any()
   @callback next_itinerary(itinerary_iterator :: any()) :: any()
   @callback get_query_id(itinerary :: any()) :: any()
+  @callback get_query(itinerary :: any()) :: any()
   @callback is_empty(itinerary :: any()) :: any()
   @callback is_terminal(itinerary :: any()) :: any()
   @callback is_valid_destination(

--- a/lib/ts/util/itinerary_behaviour.ex
+++ b/lib/ts/util/itinerary_behaviour.ex
@@ -5,6 +5,7 @@ defmodule Util.ItineraryBehaviour do
   @callback update_days_travelled(itinerary :: any()) :: any()
   @callback valid_itinerary_iterator(any(), any()) :: any()
   @callback next_itinerary(itinerary_iterator :: any()) :: any()
+  @callback get_itinerary(any()) :: any()
   @callback get_query_id(itinerary :: any()) :: any()
   @callback get_query(itinerary :: any()) :: any()
   @callback is_empty(itinerary :: any()) :: any()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,4 +2,6 @@ ExUnit.start()
 Mox.defmock(MockCollector, for: Station.CollectorBehaviour)
 Mox.defmock(MockRegister, for: Station.RegistryBehaviour)
 Mox.defmock(MockStation, for: Station.StationBehaviour)
+Mox.defmock(MockItinerary, for: Util.ItineraryBehaviour)
+Mox.defmock(MockUQC, for: Station.UQCBehaviour)
 #ExUnit.configure exclude: [:slow]

--- a/test/ts/collector_test.exs
+++ b/test/ts/collector_test.exs
@@ -43,7 +43,11 @@ defmodule CollectorTest do
     itinerary4 = get_terminal_itinerary(query, preference, 4)
     itinerary5 = get_terminal_itinerary(query, preference, 4)
 
-    result = [itinerary5, itinerary4, itinerary3, itinerary2, itinerary1]
+    result =
+      [itinerary5, itinerary4, itinerary3, itinerary2, itinerary1]
+      |> Enum.map(fn itinerary_acc ->
+        Itinerary.get_itinerary(itinerary_acc)
+      end)
 
     station_pid = :c.pid(0, 99, 1)
     station_code = query.src_station
@@ -63,6 +67,7 @@ defmodule CollectorTest do
     |> expect(:send_query, fn ^station_pid, ^itinerary -> nil end)
 
     MockItinerary
+    |> expect(:get_itinerary, 5, fn {_, itinerary, _} -> itinerary end)
     |> expect(:get_query, fn {query, _, _} -> query end)
     |> expect(:get_query_id, 7, fn {query, _, _} -> query.qid end)
 
@@ -113,7 +118,11 @@ defmodule CollectorTest do
     itinerary2 = get_terminal_itinerary(query, preference, 4)
     itinerary3 = get_terminal_itinerary(query, preference, 4)
 
-    result = [itinerary3, itinerary2, itinerary1]
+    result =
+      [itinerary3, itinerary2, itinerary1]
+      |> Enum.map(fn itinerary_acc ->
+        Itinerary.get_itinerary(itinerary_acc)
+      end)
 
     station_pid = :c.pid(0, 99, 1)
     station_code = query.src_station
@@ -133,6 +142,7 @@ defmodule CollectorTest do
     |> expect(:send_query, fn ^station_pid, ^itinerary -> nil end)
 
     MockItinerary
+    |> expect(:get_itinerary, 3, fn {_, itinerary, _} -> itinerary end)
     |> expect(:get_query, fn {query, _, _} -> query end)
     |> expect(:get_query_id, 5, fn {query, _, _} -> query.qid end)
 
@@ -159,7 +169,7 @@ defmodule CollectorTest do
   end
 
   def get_terminal_itinerary(query, preference, n) when n >= 0 do
-    route = loop(n, [], query.src_station)
+    route = loop(n - 1, [], query.src_station)
     last_link = List.first(route)
     src_station = last_link.dst_station
     dst_station = query.dst_station

--- a/test/ts/collector_test.exs
+++ b/test/ts/collector_test.exs
@@ -1,0 +1,210 @@
+defmodule CollectorTest do
+  @moduledoc """
+  Define tests for the Query Collector Module
+  """
+
+  use ExUnit.Case, async: true
+  import Mox
+  alias Station.QueryCollector, as: QC
+  alias Util.Itinerary, as: Itinerary
+  alias Util.Query, as: Query
+  alias Util.Connection, as: Connection
+  alias Util.Preference, as: Preference
+
+  @dependency %{
+    uqc: MockUQC,
+    itinerary: MockItinerary,
+    registry: MockRegister,
+    station: MockStation
+  }
+
+  test "Normal working of Query Collector with number of completed itineraries equal to max_itineraries" do
+    query = %Query{
+      qid: "0300",
+      src_station: 0,
+      dst_station: 3,
+      arrival_time: 0,
+      end_time: 999_999
+    }
+
+    preference = %Preference{day: 0}
+
+    itinerary = Itinerary.new(query, preference)
+
+    # Set options for QC process
+    opts = %{max_itineraries: 5, timeout: 100}
+
+    dependency = @dependency
+
+    # Get 5 random terminal itineraries of length 4
+    itinerary1 = get_terminal_itinerary(query, preference, 4)
+    itinerary2 = get_terminal_itinerary(query, preference, 4)
+    itinerary3 = get_terminal_itinerary(query, preference, 4)
+    itinerary4 = get_terminal_itinerary(query, preference, 4)
+    itinerary5 = get_terminal_itinerary(query, preference, 4)
+
+    result = [itinerary5, itinerary4, itinerary3, itinerary2, itinerary1]
+
+    station_pid = :c.pid(0, 99, 1)
+    station_code = query.src_station
+    qid = query.qid
+
+    {:ok, pid} = QC.start_link(itinerary, opts, dependency)
+
+    MockUQC
+    |> expect(:receive_search_results, fn ^result -> nil end)
+
+    MockRegister
+    |> expect(:lookup_code, fn ^station_code -> station_pid end)
+    |> expect(:unregister_query, fn ^qid -> nil end)
+    |> expect(:lookup_query_id, 5, fn ^qid -> pid end)
+
+    MockStation
+    |> expect(:send_query, fn ^station_pid, ^itinerary -> nil end)
+
+    MockItinerary
+    |> expect(:get_query, fn {query, _, _} -> query end)
+    |> expect(:get_query_id, 7, fn {query, _, _} -> query.qid end)
+
+    # Give access to UQC process to mocks.
+    allow(MockUQC, self(), pid)
+    allow(MockItinerary, self(), pid)
+    allow(MockRegister, self(), pid)
+    allow(MockStation, self(), pid)
+
+    # Initialise Query
+    QC.search_itinerary(pid)
+
+    QC.collect(itinerary1, dependency)
+    QC.collect(itinerary2, dependency)
+    QC.collect(itinerary3, dependency)
+    QC.collect(itinerary4, dependency)
+    QC.collect(itinerary5, dependency)
+
+    # Wait for the station to terminate
+    wait_for_process_termination(pid)
+
+    verify!(MockStation)
+    verify!(MockUQC)
+    verify!(MockRegister)
+    verify!(MockItinerary)
+  end
+
+  test "Normal working of Query Collector with completed itineraries not exceeding max_itineraries" do
+    query = %Query{
+      qid: "0300",
+      src_station: 0,
+      dst_station: 3,
+      arrival_time: 0,
+      end_time: 999_999
+    }
+
+    preference = %Preference{day: 0}
+
+    itinerary = Itinerary.new(query, preference)
+
+    # Set options for QC process
+    opts = %{max_itineraries: 5, timeout: 100}
+
+    dependency = @dependency
+
+    # Get 5 random terminal itineraries of length 4
+    itinerary1 = get_terminal_itinerary(query, preference, 4)
+    itinerary2 = get_terminal_itinerary(query, preference, 4)
+    itinerary3 = get_terminal_itinerary(query, preference, 4)
+
+    result = [itinerary3, itinerary2, itinerary1]
+
+    station_pid = :c.pid(0, 99, 1)
+    station_code = query.src_station
+    qid = query.qid
+
+    {:ok, pid} = QC.start_link(itinerary, opts, dependency)
+
+    MockUQC
+    |> expect(:receive_search_results, fn ^result -> nil end)
+
+    MockRegister
+    |> expect(:lookup_code, fn ^station_code -> station_pid end)
+    |> expect(:unregister_query, fn ^qid -> nil end)
+    |> expect(:lookup_query_id, 3, fn ^qid -> pid end)
+
+    MockStation
+    |> expect(:send_query, fn ^station_pid, ^itinerary -> nil end)
+
+    MockItinerary
+    |> expect(:get_query, fn {query, _, _} -> query end)
+    |> expect(:get_query_id, 5, fn {query, _, _} -> query.qid end)
+
+    # Give access to UQC process to mocks.
+    allow(MockUQC, self(), pid)
+    allow(MockItinerary, self(), pid)
+    allow(MockRegister, self(), pid)
+    allow(MockStation, self(), pid)
+
+    # Initialise Query
+    QC.search_itinerary(pid)
+
+    QC.collect(itinerary1, dependency)
+    QC.collect(itinerary2, dependency)
+    QC.collect(itinerary3, dependency)
+
+    # Wait for the station to terminate
+    wait_for_process_termination(pid)
+
+    verify!(MockStation)
+    verify!(MockUQC)
+    verify!(MockRegister)
+    verify!(MockItinerary)
+  end
+
+  def get_terminal_itinerary(query, preference, n) when n >= 0 do
+    route = loop(n, [], query.src_station)
+    last_link = List.first(route)
+    src_station = last_link.dst_station
+    dst_station = query.dst_station
+    dept_time = :rand.uniform(10)
+    arrival_time = :rand.uniform(10)
+    vid = Integer.to_string(:rand.uniform(10_000))
+    mode_of_transport = Integer.to_string(:rand.uniform(10_000))
+
+    last_connection = %Connection{
+      vehicleID: vid,
+      src_station: src_station,
+      mode_of_transport: mode_of_transport,
+      dst_station: dst_station,
+      dept_time: dept_time,
+      arrival_time: arrival_time
+    }
+
+    {query, [last_connection | route], preference}
+  end
+
+  def loop(n, acc, src_station) when n > 0 do
+    vid = Integer.to_string(:rand.uniform(10_000))
+    mode_of_transport = Integer.to_string(:rand.uniform(10_000))
+    dst_station = src_station + 1
+    dept_time = :rand.uniform(10)
+    arrival_time = :rand.uniform(10)
+
+    connection = %Connection{
+      vehicleID: vid,
+      src_station: src_station,
+      mode_of_transport: mode_of_transport,
+      dst_station: dst_station,
+      dept_time: dept_time,
+      arrival_time: arrival_time
+    }
+
+    loop(n - 1, [connection | acc], dst_station)
+  end
+
+  def loop(0, acc, _), do: acc
+
+  def wait_for_process_termination(pid) do
+    if Process.alive?(pid) do
+      Process.sleep(10)
+      wait_for_process_termination(pid)
+    end
+  end
+end

--- a/test/ts/station_FSM_test.exs
+++ b/test/ts/station_FSM_test.exs
@@ -360,7 +360,7 @@ defmodule StationFSMTest do
 
     # Mock collector for mocking the QC
     MockCollector
-    |> expect(:collect, fn _ -> send(test_proc, :collected) end)
+    |> expect(:collect, fn _, ^dependency -> send(test_proc, :collected) end)
 
     # New Fsm
     station_fsm = FSM.initialise_fsm([station_state, dependency])

--- a/test/ts/station_contract_test.exs
+++ b/test/ts/station_contract_test.exs
@@ -405,7 +405,7 @@ defmodule StationContractTest do
 
     # Define the expectation for the Mock of the Query Collector
     MockCollector
-    |> expect(:collect, fn itinerary ->
+    |> expect(:collect, fn itinerary, ^dependency ->
       send(test_proc, {:itinerary_received, itinerary})
     end)
 


### PR DESCRIPTION
The Query Collector is designed such that on receiving a set (set as max_itineraries) number of itineraries, it will send the completed itineraries obtained to the query collector and terminate.

In case the number of valid itineraries for the query is less less than max_itineraries then a timeout has been added such that if the Query Collector does not receive any message for a period of time (set as timeout) then it will send the Itineraries obtained till that point to UQC and terminate.